### PR TITLE
Update RNTrackPlayer.swift

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayer.swift
@@ -75,6 +75,7 @@ public class RNTrackPlayer: RCTEventEmitter {
     @objc(supportedEvents)
     override public func supportedEvents() -> [String] {
         return [
+            "playback-audio-ended",
             "playback-queue-ended",
             "playback-state",
             "playback-error",


### PR DESCRIPTION
"playback-audio-ended" event added at time of end audio - For iOS Only