### PR TITLE
Update RNTrackPlayerAudioPlayer.swift

### DIFF
--- a/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
+++ b/ios/RNTrackPlayer/RNTrackPlayerAudioPlayer.swift
@@ -99,7 +99,13 @@ public class RNTrackPlayerAudioPlayer: QueuedAudioPlayer {
 				"track": (self.currentItem as? Track)?.id,
 				"position": self.currentTime,
 				])
-		} 
+	} else {
+            self.reactEventEmitter.sendEvent(withName: "playback-audio-ended", body: [
+                "track": (self.currentItem as? Track)?.id,
+                "position": self.currentTime,
+                ])
+        }
+
 		super.AVWrapperItemDidPlayToEndTime()
     }
 


### PR DESCRIPTION
"playback-audio-ended" event added at time of end audio - For iOS Only